### PR TITLE
use yaml.safe_load to load weights

### DIFF
--- a/src/ros_dmp/roll_dmp.py
+++ b/src/ros_dmp/roll_dmp.py
@@ -72,7 +72,7 @@ class RollDmp():
     def load_weights(self, file_name):
 
         with open(file_name) as f:
-            loadeddict = yaml.load(f)
+            loadeddict = yaml.safe_load(f)
         x = loadeddict.get('x')
         y = loadeddict.get('y')
         z = loadeddict.get('z')


### PR DESCRIPTION
In newer yaml versions, using load() will cause error. For more details, take a look at the relevant [StackOverflow thread](https://stackoverflow.com/questions/1773805/how-can-i-parse-a-yaml-file-in-python/1774043).